### PR TITLE
fix(Dockerfile): global installations are not necessary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN apk add --update curl && \
 COPY package.json .
 COPY package-lock.json .
 ADD . .
-RUN npm install -g @prisma/client prisma && prisma generate
+RUN npm install
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
Prisma and Prism Client as dependency and devDependency of the actual project are preferrable.